### PR TITLE
explicitly name assign_taxonomy to avoid click issues

### DIFF
--- a/shogun/__main__.py
+++ b/shogun/__main__.py
@@ -313,7 +313,7 @@ def _load_metadata(database):
         raise Exception("Unable to load database at %s" % os.path.abspath(metadata_file))
 
 
-@cli.command(help="Run the SHOGUN taxonomic profile algorithm on an alignment output.")
+@cli.command(name='assign_taxonomy', help="Run the SHOGUN taxonomic profile algorithm on an alignment output.")
 @click.option('-a', '--aligner', type=click.Choice(['auto', 'bowtie2', 'burst', 'utree']), default='auto',
               help='The aligner to use.', show_default=True)
 @click.option('--capitalist/--no-capitalist', default=True, help='Run capitalist with burst post-align or not.')

--- a/shogun/__main__.py
+++ b/shogun/__main__.py
@@ -190,7 +190,7 @@ def functional(ctx, input, database, output, level):
     _function([input], database, output, [level], save_median_taxatable=True)
 
 
-@cli.command(help="Run the SHOGUN functional algorithm on a taxonomic profile.")
+@cli.command(name='summarize_functional', help="Run the SHOGUN functional algorithm on a taxonomic profile.")
 @click.option('-i', '--input', type=click.Path(resolve_path=True, exists=True, allow_dash=True), required=True, help="The taxatable.")
 @click.option('-d', '--database', type=click.Path(resolve_path=True, exists=True), required=True, help="The path to the folder containing the database.")
 @click.option('-o', '--output', type=click.Path(resolve_path=True, writable=True), default=os.path.join(os.getcwd(), date.today().strftime('results-%y%m%d')), help='The output file', show_default=True)


### PR DESCRIPTION
`assign_taxonomy` registers as-is in click < 7.0, but as `assign-taxonomy` in click 7.0... explicit naming will prevent this issue.